### PR TITLE
Integrate timezone handling and display time for device and browser

### DIFF
--- a/lib/client/clock-client.js
+++ b/lib/client/clock-client.js
@@ -1,8 +1,11 @@
 'use strict';
 
 var browserSettings = require('./browser-settings');
+var moment = require('moment-timezone');
+var timeformat = require('./timeformat');
 var client = {};
 var latestProperties = {};
+var profileTimezone = null;
 
 client.query = function query () {
   var parts = (location.search || '?').substring(1).split('&');
@@ -31,6 +34,39 @@ client.query = function query () {
     , success: function gotData (data) {
       latestProperties = data;
       client.render();
+    }
+  });
+};
+
+client.queryProfile = function queryProfile () {
+  var parts = (location.search || '?').substring(1).split('&');
+  var token = '';
+  parts.forEach(function(val) {
+    if (val.startsWith('token=')) {
+      token = val.substring('token='.length);
+    }
+  });
+
+  var secret = localStorage.getItem('apisecrethash');
+  var src = '/api/v1/profile.json';
+
+  if (secret) {
+    var s = '?secret=' + secret;
+    src += s;
+  } else if (token) {
+    var s2 = '?token=' + token;
+    src += s2;
+  }
+
+  $.ajax(src, {
+    error: function gotError (err) {
+      console.error('Error fetching profile:', err);
+    }
+    , success: function gotData (data) {
+      if (data && data.length > 0 && data[0].store && data[0].store.Default && data[0].store.Default.timezone) {
+        profileTimezone = data[0].store.Default.timezone;
+        console.log('Profile timezone:', profileTimezone);
+      }
     }
   });
 };
@@ -189,23 +225,72 @@ client.render = function render () {
 
 function updateClock () {
   let timeDivisor = parseInt(client.settings.timeFormat ? client.settings.timeFormat : 12, 10);
-  let today = new Date()
-    , h = today.getHours() % timeDivisor;
+
+  // Get device time and offset using shared utilities
+  let deviceTime = timeformat.getDeviceTime(profileTimezone, moment);
+  let deviceOffsetSeconds = timeformat.getTimezoneOffsetSeconds(profileTimezone, moment);
+
+  // Fall back to browser time if no device timezone
+  if (!deviceTime) {
+    deviceTime = new Date();
+  }
+
+  // Format device time
+  let h = deviceTime.getHours() % timeDivisor;
   if (timeDivisor === 12) {
     h = (h === 0) ? 12 : h; // In the case of 00:xx, change to 12:xx for 12h time
   }
   if (timeDivisor === 24) {
     h = (h < 10) ? ("0" + h) : h; // Pad the hours with a 0 in 24h time
   }
-  let m = today.getMinutes();
+  let m = deviceTime.getMinutes();
   if (m < 10) m = "0" + m;
-  $('.tm').html(h + ":" + m);
+
+  // Check if we need to show both times (different UTC offsets)
+  let showBothTimes = timeformat.shouldShowBothTimes(deviceOffsetSeconds);
+
+  if (showBothTimes) {
+    // Format browser local time
+    let browserTime = new Date();
+    let browserH = browserTime.getHours() % timeDivisor;
+    if (timeDivisor === 12) {
+      browserH = (browserH === 0) ? 12 : browserH;
+    }
+    if (timeDivisor === 24) {
+      browserH = (browserH < 10) ? ("0" + browserH) : browserH;
+    }
+    let browserM = browserTime.getMinutes();
+    if (browserM < 10) browserM = "0" + browserM;
+
+    // Display both times with separate spans for styling
+    $('.tm').html(
+      h + ":" + m + " <span class=\"device-label\">(Device)</span><br>" +
+      "<span class=\"local-time\">" + browserH + ":" + browserM + " (Local)</span>"
+    );
+
+    // Apply styles via CSS
+    $('.tm .device-label').css({
+      'font-size': '0.6em',
+      'opacity': '0.7'
+    });
+    $('.tm .local-time').css({
+      'font-size': '0.8em',
+      'opacity': '0.6'
+    });
+  } else {
+    // Display only device time (or browser time if no device data)
+    $('.tm').html(h + ":" + m);
+  }
 }
 
 client.init = function init () {
 
   console.log('Initializing clock');
   client.settings = browserSettings(client, window.serverSettings, $);
+
+  // Fetch profile timezone once on initialization
+  client.queryProfile();
+
   client.query();
   setInterval(client.query, 20 * 1000); // update every 20 seconds
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -13,6 +13,7 @@ var units = require('../units')();
 var levels = require('../levels');
 var times = require('../times');
 var receiveDData = require('./receiveddata');
+var timeformat = require('./timeformat');
 
 var brushing = false;
 
@@ -874,7 +875,40 @@ client.load = function load (serverSettings, callback) {
       return;
     }
     client.now = Date.now();
-    $('#currentTime').text(formatTime(new Date(client.now), true)).css('text-decoration', '');
+
+    // Get device timezone from profile
+    var deviceTimezone = client.profilefunctions && client.profilefunctions.getTimezone ? client.profilefunctions.getTimezone() : null;
+
+    // Get device time and offset using shared utilities
+    var deviceTime = timeformat.getDeviceTime(deviceTimezone, moment);
+    var deviceOffsetSeconds = timeformat.getTimezoneOffsetSeconds(deviceTimezone, moment);
+
+    // Fall back to browser time if no device timezone
+    if (!deviceTime) {
+      deviceTime = new Date(client.now);
+    }
+
+    // Check if we need to show both times (different UTC offsets)
+    var showBothTimes = timeformat.shouldShowBothTimes(deviceOffsetSeconds);
+
+    if (showBothTimes) {
+      var browserTime = new Date(client.now);
+      $('#currentTime')
+        .html(formatTime(deviceTime, true) + ' <span class="device-label">(Device)</span> <span class="local-time">' + formatTime(browserTime, true) + ' (Local)</span>')
+        .css('text-decoration', '');
+
+      // Apply styles via CSS
+      $('#currentTime .device-label').css({
+        'font-size': '0.8em',
+        'opacity': '0.7'
+      });
+      $('#currentTime .local-time').css({
+        'font-size': '0.8em',
+        'opacity': '0.6'
+      });
+    } else {
+      $('#currentTime').text(formatTime(deviceTime, true)).css('text-decoration', '');
+    }
   }
 
   function getClientAlarm (level, group) {

--- a/lib/client/timeformat.js
+++ b/lib/client/timeformat.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Shared timezone formatting utilities for displaying device and browser times
+ */
+
+/**
+ * Calculate timezone offset in seconds from a timezone string using moment-timezone
+ * @param {string} timezone - Timezone string (e.g., "Etc/GMT-1")
+ * @param {object} moment - moment-timezone instance
+ * @returns {number|null} - Offset in seconds, or null if timezone is invalid
+ */
+function getTimezoneOffsetSeconds(timezone, moment) {
+  if (!timezone || !moment || !moment.tz) {
+    return null;
+  }
+  try {
+    var deviceMoment = moment().tz(timezone);
+    return deviceMoment.utcOffset() * 60; // Convert minutes to seconds
+  } catch (err) {
+    console.error('Error calculating timezone offset:', err);
+    return null;
+  }
+}
+
+/**
+ * Get current time in a specific timezone
+ * @param {string} timezone - Timezone string (e.g., "Etc/GMT-1")
+ * @param {object} moment - moment-timezone instance
+ * @returns {Date|null} - Date object in device timezone, or null if timezone is invalid
+ */
+function getDeviceTime(timezone, moment) {
+  if (!timezone || !moment || !moment.tz) {
+    return null;
+  }
+  try {
+    return moment().tz(timezone).toDate();
+  } catch (err) {
+    console.error('Error getting device time:', err);
+    return null;
+  }
+}
+
+/**
+ * Get browser timezone offset in seconds
+ * @returns {number} - Browser timezone offset in seconds
+ */
+function getBrowserOffsetSeconds() {
+  return -new Date().getTimezoneOffset() * 60;
+}
+
+/**
+ * Check if device and browser timezones have different UTC offsets
+ * @param {number|null} deviceOffsetSeconds - Device timezone offset in seconds
+ * @returns {boolean} - True if offsets differ
+ */
+function shouldShowBothTimes(deviceOffsetSeconds) {
+  if (deviceOffsetSeconds === null) {
+    return false;
+  }
+  var browserOffsetSeconds = getBrowserOffsetSeconds();
+  return deviceOffsetSeconds !== browserOffsetSeconds;
+}
+
+module.exports = {
+  getTimezoneOffsetSeconds: getTimezoneOffsetSeconds,
+  getDeviceTime: getDeviceTime,
+  getBrowserOffsetSeconds: getBrowserOffsetSeconds,
+  shouldShowBothTimes: shouldShowBothTimes
+};


### PR DESCRIPTION
Enhance the application to fetch and display device timezone information, allowing for accurate representation of both device and browser times. We take the timezone from the profiles collection, so this works with pumps and non-pump users. It shows both times only when there's a different between the UTC offsets.